### PR TITLE
Remove LoaderGetOS() call.

### DIFF
--- a/src/scfb_driver.c
+++ b/src/scfb_driver.c
@@ -195,18 +195,7 @@ static pointer
 ScfbSetup(pointer module, pointer opts, int *errmaj, int *errmin)
 {
 	static Bool setupDone = FALSE;
-	const char *osname;
 
-	/* Check that we're being loaded on a OpenBSD or NetBSD system. */
-	LoaderGetOS(&osname, NULL, NULL, NULL);
-	if (!osname || (strcmp(osname, "freebsd") != 0 && strcmp(osname, "openbsd") != 0 &&
-	                strcmp(osname, "netbsd") != 0)) {
-		if (errmaj)
-			*errmaj = LDR_BADOS;
-		if (errmin)
-			*errmin = 0;
-		return NULL;
-	}
 	if (!setupDone) {
 		setupDone = TRUE;
 		xf86AddDriver(&SCFB, module, HaveDriverFuncs);


### PR DESCRIPTION
https://cgit.freedesktop.org/xorg/driver/xf86-video-v4l/commit/?id=74d39213
https://gitlab.freedesktop.org/xorg/xserver/commit/366f23c6eb504fc23112f121769bcb719948474f
Without this change scfb fail to load with xorg 1.20.4.