### PR TITLE
Fix loading the driver when compiled for xorg 1.20.7

### DIFF
--- a/src/scfb_driver.c
+++ b/src/scfb_driver.c
@@ -584,6 +584,18 @@ ScfbPreInit(ScrnInfoPtr pScrn, int flags)
 	return TRUE;
 }
 
+static void
+scfbUpdateRotatePacked(ScreenPtr pScreen, shadowBufPtr pBuf)
+{
+    shadowUpdateRotatePacked(pScreen, pBuf);
+}
+
+static void
+scfbUpdatePacked(ScreenPtr pScreen, shadowBufPtr pBuf)
+{
+    shadowUpdatePacked(pScreen, pBuf);
+}
+
 static Bool
 ScfbCreateScreenResources(ScreenPtr pScreen)
 {
@@ -602,7 +614,7 @@ ScfbCreateScreenResources(ScreenPtr pScreen)
 	pPixmap = pScreen->GetScreenPixmap(pScreen);
 
 	if (!shadowAdd(pScreen, pPixmap, fPtr->rotate ?
-		shadowUpdateRotatePackedWeak() : shadowUpdatePackedWeak(),
+		scfbUpdateRotatePacked : scfbUpdatePacked,
 		ScfbWindowLinear, fPtr->rotate, NULL)) {
 		return FALSE;
 	}


### PR DESCRIPTION
When loading scfb on xorg 1.20.7 it fails with an
undefined symbol error:

  scfb trace: probe start
  scfb trace: probe done
  scfb: PreInit 0
  scfb: PreInit done
  scfb: ScfbScreenInit 0
          bitsPerPixel=32, depth=24, defaultVisual=TrueColor
          mask: ff0000,ff00,ff, offset: 16,8,0
  mmap returns: addr 0x805a10000 len 0x640000, fd 12, off 0
  scfb: ScfbSave 0
  scfb: ScfbSave done
  scfb: ScfbScreenInit done
  ld-elf.so.1: /usr/local/lib/xorg/modules/drivers/scfb_drv.so: Undefined
  symbol "shadowUpdatePackedWeak"

Disabling ShadowFB makes the driver load, but breaks output.

With this fix, the driver loads and was reported to work
properly (at least for "normal" daily use).

The fix was inspired by a similar change in fbdev:
https://github.com/freedesktop/xf86-video-fbdev/commit/2673e727063fe28310836f1e6e9eda552930218a